### PR TITLE
Externalisation of UnifiedViews theme

### DIFF
--- a/frontend/src/main/java/cz/cuni/mff/xrg/odcs/frontend/ModTheme.java
+++ b/frontend/src/main/java/cz/cuni/mff/xrg/odcs/frontend/ModTheme.java
@@ -1,7 +1,0 @@
-package cz.cuni.mff.xrg.odcs.frontend;
-
-import com.vaadin.annotations.Theme;
-
-@Theme("ModTheme")
-public class ModTheme extends AppEntry {
-}

--- a/frontend/src/main/java/cz/cuni/mff/xrg/odcs/frontend/UnifiedViewsTheme.java
+++ b/frontend/src/main/java/cz/cuni/mff/xrg/odcs/frontend/UnifiedViewsTheme.java
@@ -1,7 +1,0 @@
-package cz.cuni.mff.xrg.odcs.frontend;
-
-import com.vaadin.annotations.Theme;
-
-@Theme("UnifiedViewsTheme")
-public class UnifiedViewsTheme extends AppEntry {
-}

--- a/frontend/src/main/java/cz/cuni/mff/xrg/odcs/frontend/UnifiedViewsUIProvider.java
+++ b/frontend/src/main/java/cz/cuni/mff/xrg/odcs/frontend/UnifiedViewsUIProvider.java
@@ -1,0 +1,17 @@
+package cz.cuni.mff.xrg.odcs.frontend;
+
+import com.vaadin.server.UICreateEvent;
+import cz.cuni.mff.xrg.odcs.commons.app.conf.AppConfig;
+import cz.cuni.mff.xrg.odcs.commons.app.conf.ConfigProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import ru.xpoft.vaadin.SpringApplicationContext;
+import ru.xpoft.vaadin.SpringUIProvider;
+
+public class UnifiedViewsUIProvider extends SpringUIProvider {
+
+    @Override
+    public String getTheme(UICreateEvent event) {
+        AppConfig appConfig = (AppConfig) SpringApplicationContext.getApplicationContext().getBean("configuration");
+        return appConfig.getString(ConfigProperty.FRONTEND_THEME);
+    }
+}

--- a/frontend/src/main/webapp/WEB-INF/classes/frontend-context.xml
+++ b/frontend/src/main/webapp/WEB-INF/classes/frontend-context.xml
@@ -78,8 +78,7 @@
     <bean id="menuLayout" class="cz.cuni.mff.xrg.odcs.frontend.gui.MenuLayout" scope="prototype"/>
 
     <!-- sessions scope -->
-
-    <bean id="ui" class="cz.cuni.mff.xrg.odcs.frontend.${frontend.theme}" scope="prototype"/>
+    <bean id="ui" class="cz.cuni.mff.xrg.odcs.frontend.AppEntry" scope="prototype"/>
 
     <bean id="pipelineHelper" class="cz.cuni.mff.xrg.odcs.frontend.auxiliaries.PipelineHelper"/>
     <bean id="pipelineValidator" class="cz.cuni.mff.xrg.odcs.frontend.auxiliaries.PipelineValidator"/>

--- a/frontend/src/main/webapp/WEB-INF/web.xml
+++ b/frontend/src/main/webapp/WEB-INF/web.xml
@@ -40,6 +40,11 @@
 			<param-value>cz.cuni.mff.xrg.odcs.frontend.AppEntry</param-value>
 		</init-param>
 		<init-param>
+			<description>Vaadin UI Provider</description>
+			<param-name>UIProvider</param-name>
+			<param-value>cz.cuni.mff.xrg.odcs.frontend.UnifiedViewsUIProvider</param-value>
+		</init-param>
+		<init-param>
 			<param-name>widgetset</param-name>
 			<param-value>cz.cuni.mff.xrg.odcs.frontend.AppWidgetSet</param-value>
 		</init-param>


### PR DESCRIPTION
refactoring which allows to develop and use themes separately from then UnifiedViews
- for creating new Theme is no longer necessary to create class which extends AppEntry
- name of Theme has to be set in frontend/config.properties in frontend.theme property
- all static content for Theme with name XYZ (frontend.theme = XYZ) has to be placed in VAADIN/themes/XYZ folder
- theme can be created separately without UnifiedViews and then copied to the deployed UV. set correctly frontend.theme property and afterward context restart is necessary 