### PR TITLE
Adding UTF8 support for property files due to rdfToVirtuosoAndCkan

### DIFF
--- a/backend/src/main/resources/backend-context.xml
+++ b/backend/src/main/resources/backend-context.xml
@@ -10,6 +10,7 @@
     <bean id="configuration"  class="cz.cuni.mff.xrg.odcs.commons.app.conf.AppConfig">
         <property name="ignoreUnresolvablePlaceholders" value="true"/>
         <property name="ignoreResourceNotFound" value="true"/>
+        <property name ="fileEncoding" value="UTF-8"/>
         <property name="locations">
             <list>
                 <value>file:${configFileLocation}</value>


### PR DESCRIPTION
this is due 
https://github.com/OpenDataNode/UVPlugin-rdfToVirtuosoAndCkan/commit/05474323a97ea4575a1fd2019cf4a7c886976caa#diff-d810277721dcfaacd82eaa60027d2f21R74
where unicode string from config is used