### PR TITLE
Pipeline canvas tabs reimplementation - only one tab remains

### DIFF
--- a/frontend/src/main/java/cz/cuni/mff/xrg/odcs/frontend/gui/views/PipelineEdit.java
+++ b/frontend/src/main/java/cz/cuni/mff/xrg/odcs/frontend/gui/views/PipelineEdit.java
@@ -159,8 +159,6 @@ public class PipelineEdit extends ViewComponent {
 
     private String canvasMode = DEVELOP_MODE;
 
-    private Tab standardTab;
-
     private Tab developTab;
 
     private Button buttonSave;
@@ -528,8 +526,6 @@ public class PipelineEdit extends ViewComponent {
         });
 
         tabSheet = new TabSheet();
-        standardTab = tabSheet.addTab(new Label(Messages.getString("PipelineEdit.under.construction")), Messages.getString("PipelineEdit.tab.standard"));
-        standardTab.setEnabled(true);
 
         //canvasPanel = new Panel(dadWrapper);
         developTab = tabSheet.addTab(dadWrapper, Messages.getString("PipelineEdit.tab.develop"));
@@ -541,11 +537,9 @@ public class PipelineEdit extends ViewComponent {
                     if (canvasMode.equals(STANDARD_MODE)) {
                         canvasMode = DEVELOP_MODE;
                         developTab.setCaption(Messages.getString("PipelineEdit.standardMode.caption.develop"));
-                        standardTab.setCaption(Messages.getString("PipelineEdit.standardMode.caption.standard"));
-                        tabSheet.setTabPosition(developTab, 1);
+                        tabSheet.setTabPosition(developTab, 0);
                     } else {
                         canvasMode = STANDARD_MODE;
-                        standardTab.setCaption(Messages.getString("PipelineEdit.developMode.caption.develop"));
                         developTab.setCaption(Messages.getString("PipelineEdit.developMode.caption.standard"));
                         tabSheet.setTabPosition(developTab, 0);
                     }
@@ -1480,15 +1474,11 @@ public class PipelineEdit extends ViewComponent {
         readOnlyLabel.setVisible(!isDevelop);
         if (isDevelop) {
             canvasMode = DEVELOP_MODE;
-            standardTab.setCaption(Messages.getString("PipelineEdit.setMode.isDevelop.standard"));
-            standardTab.setEnabled(false);
             developTab.setCaption(Messages.getString("PipelineEdit.setMode.isDevelop.develop"));
             tabSheet.setTabPosition(developTab, 0);
             pipelineCanvas.changeMode(canvasMode);
         } else {
             canvasMode = STANDARD_MODE;
-            standardTab.setCaption(Messages.getString("PipelineEdit.setMode.isStandard.develop"));
-            standardTab.setEnabled(false);
             developTab.setCaption(Messages.getString("PipelineEdit.setMode.isStandard.standard"));
             tabSheet.setTabPosition(developTab, 0);
             pipelineCanvas.changeMode(canvasMode);


### PR DESCRIPTION
In old implementation, pipeline canvas has 2 tabs - developer and standard.
However, user cannot in any way switch between these 2 tabs, which is very confusing.
Actually developer tab is displayed when user has permission to edit the pipeline, standard tab is displayed when pipeline is read only for the user. The other tab is always disabled. 
Moreover, actually only the tab labels changes when the particular tab is displayed.

So it was decided, that this second tab should be removed.

This change request originated from tests done by @OskarStoffan 

### Screen shots:
#### Before - develop tab
![pipeline_canvas_two_tabs_devel](https://cloud.githubusercontent.com/assets/10461994/9939125/e8c2b9d4-5d68-11e5-8ad2-1d5b5c631bfb.png)

#### Before - standard tab
![pipeline_canvas_two_tabs_standard](https://cloud.githubusercontent.com/assets/10461994/9939136/01079726-5d69-11e5-95f4-17e3a42eebf3.png)

#### After - only one tab - in this case developer
![pipeline_canvas_single_tab](https://cloud.githubusercontent.com/assets/10461994/9939149/107919f0-5d69-11e5-8b40-9bc6272d612c.png)

