### PR TITLE
OpenDataNode/open-data-node#128 - fix change info level to warn

### DIFF
--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -13,12 +13,12 @@
     <logger name="httpclient.wire.header" level="WARN"/>
     <logger name="httpclient.wire.content" level="WARN"/>
 
-	<!-- This is used to log whole HTTP communication. With SparlqEndpoint, that use SparqlRepository,
-	this produce a huge amount of logs per a DPU execution. -->
-	<logger name="org.apache.http.wire" level="WARN"/>
-	<logger name="org.apache.http.headers" level="WARN"/>
+    <!-- This is used to log whole HTTP communication. With SparlqEndpoint, that use SparqlRepository,
+    this produce a huge amount of logs per a DPU execution. -->
+    <logger name="org.apache.http.wire" level="WARN"/>
+    <logger name="org.apache.http.headers" level="WARN"/>
 
-    <root level="WARN">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/backend/src/main/resources/logback.xml
+++ b/backend/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
     </appender>
 
     <logger name="org.springframework" level="WARN"/>
-    <logger name="org.eclipse.persistence" level="INFO"/>
+    <logger name="org.eclipse.persistence" level="WARN"/>
     <logger name="org.eclipse.persistence.logging.metadata" level="WARN"/>
     <logger name="org.apache.commons.httpclient" level="WARN"/>
     <logger name="httpclient.wire.header" level="WARN"/>
@@ -15,10 +15,10 @@
 
 	<!-- This is used to log whole HTTP communication. With SparlqEndpoint, that use SparqlRepository,
 	this produce a huge amount of logs per a DPU execution. -->
-	<logger name="org.apache.http.wire" level="INFO"/>
-	<logger name="org.apache.http.headers" level="INFO"/>
+	<logger name="org.apache.http.wire" level="WARN"/>
+	<logger name="org.apache.http.headers" level="WARN"/>
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/frontend/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/frontend/src/main/webapp/WEB-INF/classes/logback.xml
@@ -53,7 +53,7 @@
     <logger name="org.eclipse.persistence" level="WARN"/>
     <logger name="org.eclipse.persistence.logging.metadata" level="WARN"/>
 
-    <root level="WARN">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE_ALL"/>
         <appender-ref ref="FILE_ERROR"/>

--- a/frontend/src/main/webapp/WEB-INF/classes/logback.xml
+++ b/frontend/src/main/webapp/WEB-INF/classes/logback.xml
@@ -50,10 +50,10 @@
     </appender>
 
     <logger name="org.springframework" level="WARN"/>
-    <logger name="org.eclipse.persistence" level="DEBUG"/>
+    <logger name="org.eclipse.persistence" level="WARN"/>
     <logger name="org.eclipse.persistence.logging.metadata" level="WARN"/>
 
-    <root level="INFO">
+    <root level="WARN">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE_ALL"/>
         <appender-ref ref="FILE_ERROR"/>


### PR DESCRIPTION
As it said on the https://github.com/OpenDataNode/open-data-node/issues/128 
It isn't good to have too an excessive logging on the production. It leads to spend all disk capacity. 