### PR TITLE
org.apache.servicemix.bundles.poi - bumped version from 3.11_1 to 3.14_1

### DIFF
--- a/lib/lib-core/pom.xml
+++ b/lib/lib-core/pom.xml
@@ -99,7 +99,7 @@
 								<dependency>
 									<groupId>org.apache.servicemix.bundles</groupId>
 									<artifactId>org.apache.servicemix.bundles.poi</artifactId>
-									<version>3.11_1</version>
+									<version>3.14_1</version>
 								</dependency>
 								<dependency>
 									<groupId>org.apache.santuario</groupId>


### PR DESCRIPTION
so that we provide matching library version to t-relational* and t-xls2csv DPUs