### PR TITLE
Feature/585 fix missing config property error

### DIFF
--- a/backend/conf/config.sample.properties
+++ b/backend/conf/config.sample.properties
@@ -48,6 +48,10 @@ backend.id = BackendServer1
 # By default set to -1 which means no executions are automatically cleaned up
 # backend.execution.cleanup.days.limit = -1
 
+# Automatic delete of old logs in days - delete all logs that are older than defined amount of days
+# By default it is set to -1 which means that no logs are automatically deleted
+# exec.log.history = -1
+
 # Connection configuration setting for relational database
 # for mysql {
 database.sql.driver  =  com.mysql.jdbc.Driver

--- a/backend/src/main/java/cz/cuni/mff/xrg/odcs/backend/pruning/Log.java
+++ b/backend/src/main/java/cz/cuni/mff/xrg/odcs/backend/pruning/Log.java
@@ -36,9 +36,8 @@ class Log {
 
         // get user settings
         Integer history = null;
-        try {
+        if (config.contains(ConfigProperty.EXECUTION_LOG_HISTORY)) {
             history = config.getInteger(ConfigProperty.EXECUTION_LOG_HISTORY);
-        } finally {
         }
 
         if (history == null || history <= -1) {


### PR DESCRIPTION
This is a fix for issue #585 :
- 'exec.log.history' is now loaded in same fashion as 'backend.execution.cleanup.days.limit' (i.e. after checking it is actually in there)
- documentation and default setting was added to sample config (again in a similar fashion as the other property)