### PR TITLE
Fixed security issue, where jsessionid parameter was in URL.

### DIFF
--- a/frontend/src/main/webapp/WEB-INF/web_sso.xml
+++ b/frontend/src/main/webapp/WEB-INF/web_sso.xml
@@ -21,6 +21,7 @@
 	</context-param>
 	<session-config>
 		<session-timeout>30</session-timeout>
+		<tracking-mode>COOKIE</tracking-mode>
 	</session-config>
 
 	<filter>
@@ -55,7 +56,7 @@
     <listener>
         <listener-class>org.jasig.cas.client.session.SingleSignOutHttpSessionListener</listener-class>
     </listener>
-    
+
     <servlet>
         <servlet-name>probe</servlet-name>
         <servlet-class>cz.cuni.mff.xrg.odcs.frontend.monitor.ProbeServlet</servlet-class>


### PR DESCRIPTION
During security review of eDemokracia/MOD, where UnifiedViews is employed as one of components, it was discovered that session ID is being placed into URL and that was flagged by reviewers as security issue.

Commit 705471f, included in this pull request, thus improves the session ID handling by forcing the ID into cookie.

Note: This is a merge of the fix which was applied to maintenance branch of version 2.2.x ensuring that fix will be available also in latest 'develop' (and then 'master').